### PR TITLE
Link qcon directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ mkdir om-slides-example
 cd om-slides-example
 git clone https://github.com/juxt/qcon2014
 git clone https://github.com/juxt/jig
+ln -s qcon2014 qcon
 cd jig
 git checkout 2.0.3
 ```


### PR DESCRIPTION
config.clj expects there to be a qcon dir to read from, not qcon2014.
Updating notes to stop error when running (go) in jig.
